### PR TITLE
fix md that is typo'ed to dn

### DIFF
--- a/ecliptictravelers.game.php
+++ b/ecliptictravelers.game.php
@@ -271,7 +271,7 @@ class EclipticTravelers extends Table
             }
         }
         if ($ft == 'n') {
-            if (in_array($t->time, ['d', 'dn', 'tn'])) {
+            if (in_array($t->time, ['d', 'md', 'tn'])) {
                 return false;
             }
         }

--- a/ecliptictravelers.js
+++ b/ecliptictravelers.js
@@ -370,7 +370,7 @@ define([
                     }
                 }
                 if (ft === 'n') {
-                    if (['d', 'dn', 'tn'].includes(t.time)) {
+                    if (['d', 'md', 'tn'].includes(t.time)) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Fix for
https://boardgamearena.com/bug?id=57427

`md` was somehow typo'ed as `dn`.