### PR TITLE
Adjust the padding in the common table

### DIFF
--- a/ecliptictravelers.css
+++ b/ecliptictravelers.css
@@ -84,7 +84,7 @@ body {
     height: 220px;
     background-color: rgba(255,255,255,0.5);
     border-radius: 10px;
-    padding: 5px;
+    padding: 5px 5px 10px;
     margin-bottom: 10px;
 }
 .ecliptictravelers-table-cards {


### PR DESCRIPTION
Cards in common table have drop shadow.
Due to that, the padding looks much smaller than what it actually has than the one in the hand.
This adds extra padding on the common table in the bottom so it looks correct.