### PR TITLE
Auto play the selected card rather asking player to press `Play`

### DIFF
--- a/ecliptictravelers.js
+++ b/ecliptictravelers.js
@@ -285,13 +285,6 @@ define([
                 case 'playerTurn':
                     if (this.isCurrentPlayerActive()) {
                         seqProc.then(() => {
-                            // TODO: check if there are any playable card
-                            this.addActionButton(
-                                'playCard_button', // id
-                                _('Play selected card.'), // translate (button label)
-                                'onPlayCard' // name of call back
-                            );
-
                             this.addActionButton(
                                 'pass_button', // id
                                 _('Pass'), // translate (button label)
@@ -603,39 +596,13 @@ define([
                   Number(this.commonTable.items[this.commonTable.items.length - 2].type);
             if (!this.isCardPlayable(tCardID, hCardID, pCardID, this.isEclipsed())) {
                 this.playerHand.unselectAll();
-            }
-        },
-
-        onEclipseSelect: function (controlName, itemID) {
-            if (!itemID) { return; }
-            this.playerHand.unselectAll();
-            if (!this.isEclipsePlayable()) {
-                this.eclipse.unselectAll();
-            }
-        },
-
-        onPlayCard: function (evt) {
-            dojo.stopEvent(evt);
-
-            const hSelected = this.playerHand.getSelectedItems();
-            const eSelected = this.eclipse.getSelectedItems();
-
-            if (hSelected.length <= 0 && eSelected.length <= 0) {
-                this.showMessage(_('No card is selected.'), 'error');
                 return;
             }
 
-            if (eSelected.length) {
-                const eclUrl = `${reqBase}/callEclipse.html`;
-                this.ajaxcall(eclUrl, {
-                    lock: true
+            const hSelected = this.playerHand.getSelectedItems();
 
-                }, this, (result) => {
-                    // console.log('success: onEclipse', arguments);
-
-                }, (is_error) => {
-                    // console.log('error: onEclipse', arguments);
-                });
+            if (hSelected.length <= 0) {
+                this.showMessage(_('No card is selected.'), 'error');
                 return;
             }
 
@@ -650,6 +617,34 @@ define([
             }, (is_error) => {
                 // console.log('error: onPlayCard', arguments);
             });
+        },
+
+        onEclipseSelect: function (controlName, itemID) {
+            if (!itemID) { return; }
+            this.playerHand.unselectAll();
+            if (!this.isEclipsePlayable()) {
+                this.eclipse.unselectAll();
+                return;
+            }
+
+            const eSelected = this.eclipse.getSelectedItems();
+
+            if (eSelected.length <= 0) {
+                this.showMessage(_('No card is selected.'), 'error');
+                return;
+            }
+
+            const eclUrl = `${reqBase}/callEclipse.html`;
+            this.ajaxcall(eclUrl, {
+                lock: true
+
+            }, this, (result) => {
+                // console.log('success: onEclipse', arguments);
+
+            }, (is_error) => {
+                // console.log('error: onEclipse', arguments);
+            });
+            return;
         },
 
         onPass: function (evt) {

--- a/ecliptictravelers.js
+++ b/ecliptictravelers.js
@@ -75,6 +75,7 @@ define([
             });
         };
     };
+    const isMobile = navigator.userAgentData?.mobile || false;
 
     return declare("bgagame.ecliptictravelers", ebg.core.gamegui, {
         constructor: function(){
@@ -285,6 +286,15 @@ define([
                 case 'playerTurn':
                     if (this.isCurrentPlayerActive()) {
                         seqProc.then(() => {
+                            // Display play button only on mobile
+                            if (isMobile) {
+                                this.addActionButton(
+                                    'playCard_button', // id
+                                    _('Play selected card.'), // translate (button label)
+                                    'onPlayCard' // name of call back
+                                );
+                            }
+
                             this.addActionButton(
                                 'pass_button', // id
                                 _('Pass'), // translate (button label)
@@ -598,6 +608,9 @@ define([
                 this.playerHand.unselectAll();
                 return;
             }
+            if (isMobile) {
+                return; // let them press `play` button instead
+            }
 
             const hSelected = this.playerHand.getSelectedItems();
 
@@ -626,6 +639,9 @@ define([
                 this.eclipse.unselectAll();
                 return;
             }
+            if (isMobile) {
+                return; // let them press `play` button instead
+            }
 
             const eSelected = this.eclipse.getSelectedItems();
 
@@ -645,6 +661,45 @@ define([
                 // console.log('error: onEclipse', arguments);
             });
             return;
+        },
+
+        // for mobile
+        onPlayCard: function (evt) {
+            dojo.stopEvent(evt);
+
+            const hSelected = this.playerHand.getSelectedItems();
+            const eSelected = this.eclipse.getSelectedItems();
+
+            if (hSelected.length <= 0 && eSelected.length <= 0) {
+                this.showMessage(_('No card is selected.'), 'error');
+                return;
+            }
+
+            if (eSelected.length) {
+                const eclUrl = `${reqBase}/callEclipse.html`;
+                this.ajaxcall(eclUrl, {
+                    lock: true
+
+                }, this, (result) => {
+                    // console.log('success: onEclipse', arguments);
+
+                }, (is_error) => {
+                    // console.log('error: onEclipse', arguments);
+                });
+                return;
+            }
+
+            const plyUrl = `${reqBase}/callPlayCard.html`;
+            this.ajaxcall(plyUrl, {
+                lock: true,
+                cards: hSelected.map(card => card.id).join(',')
+
+            }, this, (result) => {
+                // console.log('success: onPlayCard', arguments);
+
+            }, (is_error) => {
+                // console.log('error: onPlayCard', arguments);
+            });
         },
 
         onPass: function (evt) {


### PR DESCRIPTION
Whenever a player select a card (either one in the hand or the eclipse), the card will be auto-played, unlike asking to press `Play` everytime.

I excluded this behavior when a player is in mobile device (though this only works with chrome.)