### PR TITLE
Fix eclipse card layout with narrow window

### DIFF
--- a/ecliptictravelers.css
+++ b/ecliptictravelers.css
@@ -97,7 +97,7 @@ body {
 .eclipse-wrapper {
     display: flex;
     flex-direction: column;
-    flex: 1 0 192px;
+    flex: 1 1 auto;
     height: 192px;
     justify-content: center;
 }


### PR DESCRIPTION
Make eclipse layout more flexible.
Set flex-shrink to 1 and flex-basis to auto on eclipse card container so that it will be shrunk when window size is getting narrower.